### PR TITLE
Use installed cert (key3.db) lmt as basis for install logic

### DIFF
--- a/renew.sh
+++ b/renew.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#set -x
+
+
 
 # Copyright (c) 2017 Antonia Stevens a@antevens.com
 
@@ -23,28 +24,34 @@
 
 # Set strict mode
 set -euo pipefail
+certbot_debug_args=""
+
+#For debugging uncomment these
+#set -x
+#certbot_debug_args="--force-renewal"
 
 # Version
 # shellcheck disable=2034
 version='0.0.3'
 
 letsencrypt_live_dir="/etc/letsencrypt/live"
+installed_cert_db="/etc/httpd/alias/key3.db"
 
+# Function to print to stderr
 errcho(){ >&2 echo $@; }
 
-# Exit if not being run as root
 if [ "${EUID:-$(id -u)}" -ne "0" ] ; then
-    errcho "This script needs superuser privileges, suggest running it as root"
+    errcho "FATAL: This script needs superuser privileges, suggest running it as root."
     exit 1
 fi
 
 if ! which ipa >/dev/null ; then
-    errcho "ipa not found; you probably need to update your PATH."
+    errcho "FATAL: ipa not found; you probably need to update your PATH."
     exit 1
 fi
 
 if ! which ipa-server-certinstall >/dev/null ; then
-    errcho "ipa-server-certinstall not found; you probably need to update your PATH."
+    errcho "FATAL: ipa-server-certinstall not found; you probably need to update your PATH."
     exit 1
 fi
 
@@ -182,6 +189,7 @@ certbot certonly --quiet \
                  --manual-public-ip-logging-ok \
                  --manual-auth-hook "${auth_hook}" \
                  ${domain_args} \
+                 ${certbot_debug_args} \
                  --agree-tos \
                  --email "${email}" \
                  --expand \


### PR DESCRIPTION
c9b7004:
    Bring fatal error output in line with others.

0685218:
   Use installed cert (key3.db) lmt as basis for install logic

   Motivation: If the cert install fails it will not get installed on
   subsiquent runs and the installed certificate will eventually expire.

   Caveats: This patch assumes that the letsencrypt_live_dir directory is only
   used for a single cert; I'm not sure how sound this assumption is.