### PR TITLE
Add a DNS propagation delay

### DIFF
--- a/renew.sh
+++ b/renew.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 version='0.0.3'
 
 letsencrypt_live_dir="/etc/letsencrypt/live"
+dns_propagation_delay="0"
 
 errcho(){ >&2 echo $@; }
 
@@ -145,7 +146,7 @@ email="${email:-${hostmaster%\.}}"
 
 # Configure the manual auth hook
 # shellcheck disable=2016
-default_auth_hook='ipa dnsrecord-mod ${CERTBOT_DOMAIN#*.}. _acme-challenge.${CERTBOT_DOMAIN}. --txt-rec=${CERTBOT_VALIDATION}'
+default_auth_hook='ipa dnsrecord-mod ${CERTBOT_DOMAIN#*.}. _acme-challenge.${CERTBOT_DOMAIN}. --txt-rec=${CERTBOT_VALIDATION} && sleep ${dns_propagation_delay}'
 
 # Configure alternative nsupdate hook
 nsupdate_auth_server="${NSUPDATE_AUTH_SERVER:-$(nslookup -type=soa "${dns_domain_name}"  | grep 'origin =' | sed -e 's/[[:space:]]*origin = //')}"


### PR DESCRIPTION
This small change makes freeipa work with a hidden master DNS. I set it to zero so there is no impact for People not using it.